### PR TITLE
Add ability to have an alternative render function for a second render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ export const frontloadConnect = (frontload, options = {}) => (component) => (pro
     options={options} />
 )
 
-export const frontloadServerRender = (render, withLogging) => {
+export const frontloadServerRender = (render, withLogging, alternativeRender) => {
   if (process.env.NODE_ENV !== 'production' && withLogging) {
     log('frontloadServerRender info', 'running first render to fill frontload fn queue(s)')
   }
@@ -219,7 +219,7 @@ export const frontloadServerRender = (render, withLogging) => {
       log('frontloadServerRender info', 'Running second render.')
     }
 
-    const output = render(false)
+    const output = typeof alternativeRender === 'function' ? alternativeRender(true) : render(false)
 
     // all queues get filled again on the second render. Just clean them, don't flush them
     cleanQueues()


### PR DESCRIPTION
Hi @davnicwil !
Thanks for your work on the library and your effort to open source community!

I faced the issue with `renderToNodeStream` [API](https://reactjs.org/docs/react-dom-server.html#rendertonodestream).
Since I haven't managed how to do the first render with `renderToNodeStream` to have a working `react-frontload` - I decided to at least try to use stream API for a second render when we already have all the data.
So this is a use-case for my PR.

Simply, allowing the user to have a second render done with any other than `renderToString` function sounds like a good idea.
It has backward compatibility and just an extra argument that can be passed.

Feel free to tag me in the comment or redo the idea in a better way.