### PR TITLE
Per-render promise queue that 'just works' without API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > A bug which caused issues with multiple server renders happening in parallel was fixed in v1.0.5.
 
-> **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so should just work with your existing code, however it requires that you are running node at version 8.0.0 or above. Node 8+ is now a hard requirement for using react-frontload - this decision was made because node 8+ has features that allow react-frontload to abstract certain internals away from the user and keep the API simple. I think this was probably the best compromise for the most users, since node 10 is now in LTS, but if you have feedback on this and want me to change it to support earlier versions of node, please let me know in issues!
+> **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so should just work with your existing code, however it requires that you are running node at version 8.0.0 or above. Node 8+ is now a hard requirement for using react-frontload - this decision was made because node 8+ has features that allow react-frontload to abstract certain internals away from the user and keep the API simple. I think this was probably the best compromise for the most users, since node 10 is now in LTS. If this creates problems for existing users, different APIs can be added that support older versions of node, but this won't be done unless people ask for it - please file an issue if you need this.
 
 Client render                   | Server render
 :------------------------------:|:-----------------------------:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 #### Load data asynchronously into your React components. Works on both client and server render.
 
+<aside class="notice">
+A bug which may have caused intermittent issues with server renders happening in parallel (due to race conditions) was fixed in **v1.0.5** - if you are using any version below **v1.0.5** you should upgrade immediately. There are no breaking changes to the API. A temporary fix for that same bug was also introduced in **v1.0.4** which did contain breaking changes to the API. To be clear, just skip over **v1.0.4** and go straight to **v1.0.5**.
+</aside>
+
 Client render                   | Server render
 :------------------------------:|:-----------------------------:
 ![](/docs/no-server-render.gif) |![](/docs/server-render.gif)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 #### Load data asynchronously into your React components. Works on both client and server render.
 
-<aside class="notice">
-A bug which may have caused intermittent issues with server renders happening in parallel (due to race conditions) was fixed in **v1.0.5** - if you are using any version below **v1.0.5** you should upgrade immediately. There are no breaking changes to the API. A temporary fix for that same bug was also introduced in **v1.0.4** which did contain breaking changes to the API. To be clear, just skip over **v1.0.4** and go straight to **v1.0.5**.
-</aside>
+> A bug which may have caused intermittent issues with server renders happening in parallel (due to race conditions) was fixed in **v1.0.5** - if you are using any version below **v1.0.5** you should upgrade immediately. There are no breaking changes to the API. A temporary fix for that same bug was also introduced in **v1.0.4** which did contain breaking changes to the API. To be clear, just skip over **v1.0.4** and go straight to **v1.0.5**.
 
 Client render                   | Server render
 :------------------------------:|:-----------------------------:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 #### Load data asynchronously into your React components. Works on both client and server render.
 
 > A bug which caused issues with multiple server renders happening in parallel was fixed in v1.0.5.
-> **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so will just work with your existing code.
+
+> **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so should just work with your existing code, however it requires that you are running node at version 8.0.0 or above. Node 8+ is now a hard requirement for using react-frontload - this decision was made because node 8+ has features that allow react-frontload to abstract certain internals away from the user and keep the API simple. I think this was probably the best compromise for the most users, since node 10 is now in LTS, but if you have feedback on this and want me to change it to support earlier versions of node, please let me know in issues!
 
 Client render                   | Server render
 :------------------------------:|:-----------------------------:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 #### Load data asynchronously into your React components. Works on both client and server render.
 
-> A critical bug which caused issues with multiple server renders happening in parallel was fixed in v1.0.5. **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so will 'just work'.
+> A bug which caused issues with multiple server renders happening in parallel was fixed in v1.0.5.
+> **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so will just work with your existing code.
 
 Client render                   | Server render
 :------------------------------:|:-----------------------------:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #### Load data asynchronously into your React components. Works on both client and server render.
 
-> A bug which may have caused intermittent issues with server renders happening in parallel (due to race conditions) was fixed in **v1.0.5** - if you are using any version below **v1.0.5** you should upgrade immediately. There are no breaking changes to the API. A temporary fix for that same bug was also introduced in **v1.0.4** which did contain breaking changes to the API. To be clear, just skip over **v1.0.4** and go straight to **v1.0.5**.
+> A critical bug which caused issues with multiple server renders happening in parallel was fixed in v1.0.5. **Upgrade immediately to v1.0.5**! It has the same API as previous versions, so will 'just work'.
 
 Client render                   | Server render
 :------------------------------:|:-----------------------------:

--- a/README.md
+++ b/README.md
@@ -137,18 +137,17 @@ The react-frontload provider Component - it must be an ancestor of **all** compo
 #### frontloadServerRender
 
 ```js
-frontloadServerRender: (renderMarkup: (dryRun: boolean, context: Object) => string)
+frontloadServerRender: (renderMarkup: (dryRun: boolean) => string)
 ```
 
 The `react-frontload` server render wrapper which **must** be used on the server to enable the synchronous data loading on server render that `react-frontload` provides. This is of course not needed if you are not using server rendering in your application.
 
 *Arguments*
 
-  * `renderMarkup: (dryRun: boolean, context: Object) => string` This function acts as the glue between `react-frontload` and your existing server render logic, making async server rendering work. It should return exactly what normal server render code returns - in most cases the output of `ReactDom.renderToString`. The arguments injected into this function are the hooks to make `react-fronload` server rendering work, you use them as follows:
+  * `renderMarkup: (dryRun: boolean) => string` This callback function acts as the glue between `react-frontload` and your existing server render logic, making async server rendering work. It should return exactly what normal server render code returns - in most cases the output of `ReactDom.renderToString`. This function injects an argument for lower-level integration with the render, for apps that need it:
     * `dryRun: boolean` This is a flag used to let you know when the 'final' server render is taking place. `react-frontload` actually runs the server render more than once, as part of its mechanic to make async server rendering work, and some libraries in the React excosystem are built with the assumption that server rendering only occurs once. For instance, `styled-components`, when it generates css on the server. For libraries such as these, you can use this flag to only run the server render parts when it is set `false`, i.e. on the final render.
-    * `context: Object` This is the internal context object used by `react-frontload`, it's required to make async server rendering work - it simply needs to be passed through to the provider like so `<Frontload context={context} ... >`. You don't need to know anything about this object and should not modify it in any way, or depend on its structure in any way (it could change in future releases) it simply allows `frontloadServerRender` to 'see inside' your application. In any case, if you don't pass through `context` then an informative Error will be thrown when `frontloadServerRender` runs.
 
-You can think of this function as injecting the logic required to make `react-frontload` synchronous data loading work, into your existing application. This is in line with the design goals of the library, i.e. there are no requirements about how your server render function works, and indeed it can work in a completely standard way. As long as it is wrapped with `frontloadServerRender`, and `context` is plugged in to the `<Frontload />` provider,  it will just work.
+You can think of this function as injecting the logic required to make `react-frontload` synchronous data loading work, into your existing application. This is in line with the design goals of the library, i.e. there are no requirements about how your server render function works, and indeed it can work in a completely standard way. As long as it is wrapped with `frontloadServerRender`,  it will just work.
 
 Importantly, this function may go away in future if more powerful mechanisms are introduced for synchronous server render in React itself. The way it works under the hood is just a workaround for the lack of this feature in React as of now.
 

--- a/example/TodoApp.js
+++ b/example/TodoApp.js
@@ -42,8 +42,8 @@ const Routes = ({ stateManager }) => (
   </Layout>
 )
 
-const App = ({ stateManager, initialState, frontloadContext }) => (
-  <Frontload context={frontloadContext} log>
+const App = ({ stateManager, initialState }) => (
+  <Frontload log>
     {stateManager
       ? (
         <Routes stateManager={stateManager} />
@@ -61,9 +61,9 @@ const Client = (props) => (
   </BrowserRouter>
 )
 
-const Server = ({ location, routerContext, frontloadContext, stateManager }) => (
+const Server = ({ location, routerContext, stateManager }) => (
   <StaticRouter location={location} context={routerContext}>
-    <App stateManager={stateManager} frontloadContext={frontloadContext} />
+    <App stateManager={stateManager} />
   </StaticRouter>
 )
 

--- a/example/server.js
+++ b/example/server.js
@@ -43,7 +43,7 @@ app.get('/server-render*', async (req, res) => {
   const sheet = new ServerStyleSheet()
 
   // this is the ordinary synchronous server rendering logic every app should have, wrapped in a function
-  const renderMarkup = (dryRun, frontloadContext) => {
+  const renderMarkup = (dryRun) => {
     console.log(dryRun
       ? `[example app] ${location} - loading data...`
       : `[example app] ${location} - all data loaded, rendering markup...`
@@ -51,7 +51,6 @@ app.get('/server-render*', async (req, res) => {
 
     const app = <TodoApp.Server
       location={location}
-      frontloadContext={frontloadContext}
       routerContext={routerContext}
       stateManager={stateManager}
     />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-frontload",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   },
   "browser": {
     "async_hooks": false
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-frontload",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Bind Async Data Dependencies to React Components",
   "main": "./lib/index.js",
   "scripts": {
@@ -74,5 +74,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+  },
+  "browser": {
+    "async_hooks": false
   }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -606,7 +606,7 @@ test('v0.0.2: Client render of <App /> with frontloads firing api calls based on
     })
 })
 
-test.only('server render in parallel (bugfix introduced in v0.0.4, should have worked since v0.0.1)', () => {
+test.only('server render in parallel (bugfix introduced in v1.0.5)', () => {
   const testServerRender = async () => {
     let store = buildCleanStore()
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -394,8 +394,8 @@ test('v0.0.1: Client render of <App /> with server rendering configured off for 
 test('v0.0.1: Server render of <App /> with all mock api call promises resolved', () => {
   const store = buildCleanStore()
 
-  const App = (props) => (
-    <Frontload context={props.context} isServer >
+  const App = () => (
+    <Frontload isServer >
       <Component1 entityId='1' store={store} >
         <Component3 entityId='2' store={store} />
         <Component2 entityId='3' store={store} >
@@ -405,8 +405,8 @@ test('v0.0.1: Server render of <App /> with all mock api call promises resolved'
     </Frontload>
   )
 
-  return frontloadServerRender((dryRun, context) => (
-    render(<App context={context} />)
+  return frontloadServerRender((dryRun) => (
+    render(<App />)
   )).then((serverRenderedMarkup) => {
     expect(MockApi.getA.withArgs('1').callCount).toBe(1)
     expect(MockApi.getB.withArgs('3').callCount).toBe(1)
@@ -422,8 +422,8 @@ test('v0.0.1: Server render of <App /> with all mock api call promises resolved'
 test('v0.0.1: Server render of <App /> with 2 mock api call promises resolved and 2 rejected', () => {
   const store = buildCleanStore()
 
-  const App = (props) => (
-    <Frontload context={props.context} isServer >
+  const App = () => (
+    <Frontload isServer >
       <Component1 entityId='1' store={store} >
         <Component3 entityId='2' store={store} mockRestrictedEntity />
         <Component2 entityId='3' store={store} mockRestrictedEntity >
@@ -433,8 +433,8 @@ test('v0.0.1: Server render of <App /> with 2 mock api call promises resolved an
     </Frontload>
   )
 
-  return frontloadServerRender((dryRun, context) => (
-    render(<App context={context} />)
+  return frontloadServerRender((dryRun) => (
+    render(<App />)
   )).then((serverRenderedMarkup) => {
     expect(MockApi.getA.withArgs('1').callCount).toBe(1)
     expect(MockApi.getB.withArgs('3', true).callCount).toBe(1)
@@ -450,8 +450,8 @@ test('v0.0.1: Server render of <App /> with 2 mock api call promises resolved an
 test('v0.0.1: Server render of <App /> with server rendering configured off globally', () => {
   const store = buildCleanStore()
 
-  const App = (props) => (
-    <Frontload context={props.context} isServer noServerRender >
+  const App = () => (
+    <Frontload isServer noServerRender >
       <Component1 entityId='1' store={store} >
         <Component3 entityId='2' store={store} />
         <Component2 entityId='3' store={store} >
@@ -461,8 +461,8 @@ test('v0.0.1: Server render of <App /> with server rendering configured off glob
     </Frontload>
   )
 
-  return frontloadServerRender((dryRun, context) => (
-    render(<App context={context} />)
+  return frontloadServerRender((dryRun) => (
+    render(<App />)
   )).then((serverRenderedMarkup) => {
     expect(MockApi.getA.withArgs('1').callCount).toBe(0)
     expect(MockApi.getB.withArgs('3').callCount).toBe(0)
@@ -478,8 +478,8 @@ test('v0.0.1: Server render of <App /> with server rendering configured off glob
 test('v0.0.1: Server render of <App /> with server rendering configured off for one component', () => {
   const store = buildCleanStore()
 
-  const App = (props) => (
-    <Frontload context={props.context} isServer >
+  const App = () => (
+    <Frontload isServer >
       <Component1 entityId='1' store={store} >
         <Component3 entityId='2' store={store} />
         <Component2 entityId='3' store={store} >
@@ -489,8 +489,8 @@ test('v0.0.1: Server render of <App /> with server rendering configured off for 
     </Frontload>
   )
 
-  return frontloadServerRender((dryRun, context) => (
-    render(<App context={context} />)
+  return frontloadServerRender((dryRun) => (
+    render(<App />)
   )).then((serverRenderedMarkup) => {
     expect(MockApi.getA.withArgs('1').callCount).toBe(1)
     expect(MockApi.getB.withArgs('3').callCount).toBe(1)
@@ -610,8 +610,8 @@ test.only('server render in parallel (bugfix introduced in v0.0.4, should have w
   const testServerRender = async () => {
     let store = buildCleanStore()
 
-    const App = (props) => (
-      <Frontload context={props.context} isServer >
+    const App = () => (
+      <Frontload isServer >
         {/*  onlyRenderChildrenWhenDataLoaded prop means that children only load once Component1's frontload has resolved with data */}
         <Component1 entityId='1' store={store} >
           <Component3 entityId='2' store={store} />
@@ -622,8 +622,8 @@ test.only('server render in parallel (bugfix introduced in v0.0.4, should have w
       </Frontload>
     )
 
-    return frontloadServerRender((dryRun, context) => (
-      render(<App context={context} />)
+    return frontloadServerRender((dryRun) => (
+      render(<App />)
     )).then((serverRenderedMarkup) => {
       assertServerRenderedMarkupStructureIsAsExpected(serverRenderedMarkup)
       assertStoreIsPopulated(store)


### PR DESCRIPTION
This PR removes the API changes introduced in v1.0.4 for `frontloadServerRender` which injected a clean context for promise queues for each render.

With this change, this is managed automatically without the user having to do anything using the node `async_hooks` API. 

This means the `frontloadServerRender` API can be reverted back to how it was - there's now no need to manually plug in the extra `context` argument.