### PR TITLE
Add option to control when frontload should update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,20 @@ class FrontloadConnectedComponent extends React.Component {
     }
   }
 
-  pushFrontload = (lifecyclePhase, isServer) => () => {
+  pushFrontload = (lifecyclePhase, isServer) => (prevProps) => {
+    if (lifecyclePhase === LIFECYCLE_PHASES.UPDATE) {
+      const { _experimental_updateFunc } = this.props.options
+      if (
+        _experimental_updateFunc &&
+        !_experimental_updateFunc(
+          prevProps.componentProps,
+          this.props.componentProps,
+        )
+      ) {
+        return
+      }
+    }
+
     const logMessage =
       process.env.NODE_ENV !== 'production'
         ? null


### PR DESCRIPTION
This PR adds `_experimental_updateFunc` to frontloadConnects options, as discussed in #33 .
I decided to make this a function instead of an array of prop keys to keep as much logic out of frontload as possible, as well as give users a little more control.
`updateFunc` should take the components `prevProps` and `newProps` as arguments and return true if the frontload function should run. This gives the ability to specify exactly when the frontload function should should run on update, without using additional middleware components.

Example:
Update only when the `id` prop changes.
```javascript

const frontload = (props) => // some function

const updateFunc = (prevProps, newProps) => prevProps.id !== newProps.id

frontloadConnect(frontload, {
    onUpdate: true,
    _experimental_updateFunc: updateFunc
}(component)
```