### PR TITLE
Introduce continueRenderingOnError config for frontloadServerRender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ server.bundle.js
 server.bundle.js.map
 client.bundle.js
 client.bundle.js.map
+.vscode

--- a/example/server.js
+++ b/example/server.js
@@ -1,25 +1,26 @@
-import "babel-regenerator-runtime"; // for async/await
-import express from "express";
-import path from "path";
-import React from "react";
-import { renderToString } from "react-dom/server";
-import serializeJavascript from "serialize-javascript";
-import TodoApp from "./TodoApp";
-import * as todoService from "./todoService";
-import { frontloadServerRender } from "../src";
-import StateManager from "./StateManager";
-import { ServerStyleSheet } from "styled-components";
+import 'babel-regenerator-runtime' // for async/await
+import express from 'express'
+import path from 'path'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import serializeJavascript from 'serialize-javascript'
+import TodoApp from './TodoApp'
+import * as todoService from './todoService'
+import { frontloadServerRender } from '../src'
+import StateManager from './StateManager'
+import { ServerStyleSheet } from 'styled-components'
 
 // change this if you need to
-const PORT = 8989;
+const PORT = 8989
 
-const app = express();
+const app = express()
 
-app.get("/client.bundle.js", (req, res) => {
-  res.sendFile(path.join(__dirname, "/client.bundle.js"));
-});
+app.get('/client.bundle.js', (req, res) => {
+  res.sendFile(path.join(__dirname, '/client.bundle.js'))
+})
 
-const toSanitizedJSONString = obj => serializeJavascript(obj, { isJSON: true });
+const toSanitizedJSONString = (obj) =>
+  serializeJavascript(obj, { isJSON: true })
 
 const buildHtml = (serverRenderedMarkup, styleTags, initialState) => `
   <html>
@@ -32,34 +33,34 @@ const buildHtml = (serverRenderedMarkup, styleTags, initialState) => `
     ${
       initialState
         ? `<script>window.initialState=${toSanitizedJSONString(
-            initialState
+            initialState,
           )}</script>`
-        : ""
+        : ''
     }
-    ${styleTags || ""}
+    ${styleTags || ''}
   </head>
   <body>
     <div id="app-root">${serverRenderedMarkup}</div>
     <script src="/client.bundle.js"></script>
   </body>
   </html>
-`;
+`
 
-const serverRenderRouter = express.Router();
+const serverRenderRouter = express.Router()
 
-serverRenderRouter.get("*", async (req, res) => {
-  const location = req.originalUrl;
-  const context = {};
-  const stateManager = StateManager.Server();
-  const sheet = new ServerStyleSheet();
+serverRenderRouter.get('*', async (req, res) => {
+  const location = req.originalUrl
+  const context = {}
+  const stateManager = StateManager.Server()
+  const sheet = new ServerStyleSheet()
 
   // this is the ordinary synchronous server rendering logic every app should have, wrapped in a function
-  const renderMarkup = dryRun => {
+  const renderMarkup = (dryRun) => {
     console.log(
       dryRun
         ? `[example app] ${location} - loading data...`
-        : `[example app] ${location} - all data loaded, rendering markup...`
-    );
+        : `[example app] ${location} - all data loaded, rendering markup...`,
+    )
 
     const app = (
       <TodoApp.Server
@@ -67,103 +68,111 @@ serverRenderRouter.get("*", async (req, res) => {
         context={context}
         stateManager={stateManager}
       />
-    );
+    )
 
     const serverRenderedMarkup = dryRun
       ? renderToString(app)
-      : renderToString(sheet.collectStyles(app));
+      : renderToString(sheet.collectStyles(app))
 
-    return serverRenderedMarkup;
-  };
+    return serverRenderedMarkup
+  }
 
-  console.log(`[example app] ${location} - starting server render`);
-  const start = Date.now();
+  console.log(`[example app] ${location} - starting server render`)
+  const start = Date.now()
 
   // to enable async server render via react-frontload, just wrap your server render function with frontloadServerRender
-  const serverRenderedMarkup = await frontloadServerRender(renderMarkup, {
-    maxNestedFrontloadComponents: 4
-  });
-  const end = Date.now();
-  const redirect = context.url;
+  try {
+    const serverRenderedMarkup = await frontloadServerRender(renderMarkup, {
+      maxNestedFrontloadComponents: 4,
+      withLogging: true,
+    })
+    const end = Date.now()
+    const redirect = context.url
 
-  if (redirect) {
-    console.log(
-      `[example app] ${location} - resolved with redirect to ${redirect}`
-    );
+    if (redirect) {
+      console.log(
+        `[example app] ${location} - resolved with redirect to ${redirect}`,
+      )
 
-    res.redirect(redirect);
-  } else {
-    console.log(
-      `[example app] ${location} - completed server render in ${end - start}ms`
-    );
+      res.redirect(redirect)
+    } else {
+      console.log(
+        `[example app] ${location} - completed server render in ${end -
+          start}ms`,
+      )
 
-    res
-      .status(200)
-      .send(
-        buildHtml(
-          serverRenderedMarkup,
-          sheet.getStyleTags(),
-          stateManager.get()
+      res
+        .status(200)
+        .send(
+          buildHtml(
+            serverRenderedMarkup,
+            sheet.getStyleTags(),
+            stateManager.get(),
+          ),
         )
-      );
+    }
+  } catch (err) {
+    console.log(`[example app] ${location} - error caught`, err)
+
+    res.status(500).send('something went wrong, check the logs')
   }
-});
+})
 
-app.use("/server-render/", serverRenderRouter);
+app.use('/server-render/', serverRenderRouter)
 
-const noServerRenderRouter = express.Router();
+const noServerRenderRouter = express.Router()
 
-noServerRenderRouter.get("*", (req, res) => {
-  console.log("hit " + req.originalUrl);
-  res.status(200).send(buildHtml());
-});
+noServerRenderRouter.get('*', (req, res) => {
+  console.log('hit ' + req.originalUrl)
+  res.status(200).send(buildHtml())
+})
 
-app.use("/no-server-render/", noServerRenderRouter);
+app.use('/no-server-render/', noServerRenderRouter)
 
-app.get("/api/todos", async (req, res) => {
-  res.type("json");
-  console.log(`[example app] GET ${req.url}: request received`);
+app.get('/api/todos', async (req, res) => {
+  res.type('json')
+  console.log(`[example app] GET ${req.url}: request received`)
 
   try {
-    const todos = await todoService.getAll();
+    const todos = await todoService.getAll()
 
-    console.log(`[example app] GET ${req.url}: sending response`);
-    res.status(200).send(todos);
+    console.log(`[example app] GET ${req.url}: sending response`)
+    res.status(200).send(todos)
   } catch (err) {
-    console.log("[example app] ERROR loading todos", err);
-    res.status(400).send();
+    console.log('[example app] ERROR loading todos', err)
+    res.status(400).send()
   }
-});
+})
 
-app.get("/api/todos/:todoId", async (req, res) => {
-  res.type("json");
-  console.log(`[example app] GET ${req.url}: request received`);
+app.get('/api/todos/:todoId', async (req, res) => {
+  res.type('json')
+  console.log(`[example app] GET ${req.url}: request received`)
 
-  const todoId = req.params.todoId;
+  const todoId = req.params.todoId
 
   try {
-    const todo = await todoService.get(req.params.todoId);
+    const todo = await todoService.get(req.params.todoId)
 
-    console.log(`[example app] GET ${req.url}: sending response`);
-    res.status(200).send(todo);
+    console.log(`[example app] GET ${req.url}: sending response`)
+    res.status(200).send(todo)
   } catch (err) {
-    console.log(`[example app] ERROR loading todo '${todoId}'`, err);
-    res.status(404).send();
+    console.log(`[example app] ERROR loading todo '${todoId}'`, err)
+    res.status(404).send()
   }
-});
+})
 
-app.get("/favicon.ico", (req, res) => {
-  res.status(404).send();
-});
+app.get('/favicon.ico', (req, res) => {
+  res.status(404).send()
+})
 
-app.get("*", (req, res) => {
-  res.redirect("/server-render");
-});
+app.get('*', (req, res) => {
+  res.redirect('/server-render')
+})
 
-app.listen(PORT, err => {
+app.listen(PORT, (err) => {
   if (err) {
-    console.log("\n\nCould not start server:\n\n", err);
+    console.log('\n\nCould not start server:\n\n', err)
   } else {
-    console.log(`\n\n> Started server, go to http://localhost:${PORT}\n\n`);
+    console.log(`\n\n> Started server, go to http://localhost:${PORT}\n\n`)
   }
-});
+})

--- a/example/todoClient.js
+++ b/example/todoClient.js
@@ -10,7 +10,9 @@ export const getAll = async () => {
 
   return res.status === 200
     ? res.json()
-    : Promise.reject(new Error(`Error fetching ${url}: status code ${res.status}`))
+    : Promise.reject(
+        new Error(`Error fetching ${url}: status code ${res.status}`),
+      )
 }
 
 export const get = async (todoId) => {
@@ -19,5 +21,7 @@ export const get = async (todoId) => {
 
   return res.status === 200
     ? res.json()
-    : Promise.reject(new Error(`Error fetching ${url}: status code ${res.status}`))
+    : Promise.reject(
+        new Error(`Error fetching ${url}: status code ${res.status}`),
+      )
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "react-frontload",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Bind Async Data Dependencies to React Components",
   "main": "./lib/index.js",
   "scripts": {
     "build": "npm run test && npx --no-install babel src -d lib",
     "test": "jest",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "example:build-client": "npx --no-install webpack --config ./example/webpack/webpack.config.client.js",
     "example:build-server": "npx --no-install webpack --config ./example/webpack/webpack.config.server.js",
     "example": "npm i && npm run example:build-client && npm run example:build-server && node ./example/build/server.bundle.js;"


### PR DESCRIPTION
Introduce continueRenderingOnError config for frontloadServerRender which swallows any errors thrown by frontload functions and carries on regardless, rendering whatever it can. 

The default behaviour is to halt and throw the first encountered error, such that no markup is rendered and the server can catch the error and respond with an error response. 

This fixes a bug introduced in the previous release which meant that errors were always swallowed and therefore there was no option to catch and act upon the first error.